### PR TITLE
changed loading screen position to fixed so user always see it

### DIFF
--- a/app/assets/stylesheets/clients/form.scss
+++ b/app/assets/stylesheets/clients/form.scss
@@ -12,6 +12,10 @@ body[id='clients-edit'], body[id='clients-update']{
       background: #1ab394;
   }
 
+  .loading-screen > div > div {
+    position: fixed;
+  }
+
   .remove-files-wrapper {
     img {
       margin: 5px;

--- a/app/javascript/components/Commons/Loading.js
+++ b/app/javascript/components/Commons/Loading.js
@@ -5,16 +5,17 @@ const Loading = props => {
   const { text, loading, ...others } = props
 
   return (
-    <LoadingScreen
-      loading={loading}
-      bgColor='#fff'
-      spinnerColor='#9ee5f8'
-      textColor='#676767'
-      text={text}
-      {...others}
-    >
-      <></>
-    </LoadingScreen>
+    <div className="loading-screen">
+      <LoadingScreen
+        loading={loading}
+        bgColor='#fff'
+        spinnerColor='#9ee5f8'
+        textColor='#676767'
+        text={text}
+        {...others}
+      >
+      </LoadingScreen>
+    </div>
   )
 }
 


### PR DESCRIPTION
UX issue, when we have long content (e.g. legal document tab of client form) and user scroll down to the bottom of page, they miss the loading message and see only white screen which lead to confusion.

By setting position to fixed, the screen appear in the middle of screen, so user can see even when he/she scroll to whatever position.